### PR TITLE
use pjm.social.gouv.fr as default domain 

### DIFF
--- a/packages/app/.k8s/templates/ingress.yaml
+++ b/packages/app/.k8s/templates/ingress.yaml
@@ -13,7 +13,7 @@ metadata:
       more_set_headers "X-Frame-Options: deny";
       more_set_headers "X-XSS-Protection: 1; mode=block";
       more_set_headers "X-Content-Type-Options: nosniff";
-      more_set_headers "Content-Security-Policy: default-src https://matomo.fabrique.social.gouv.fr/; connect-src *.dev.fabrique.social.gouv.fr https://api-emjpm.fabrique.social.gouv.fr/api/ https://emjpm.fabrique.social.gouv.fr https://hasura-emjpm.fabrique.social.gouv.fr/v1/graphql https://matomo.fabrique.social.gouv.fr/ https://openmaptiles.geo.data.gouv.fr/ https://openmaptiles.github.io/ https://api-adresse.data.gouv.fr https://entreprise.data.gouv.fr https://nominatim.openstreetmap.org; font-src 'self'; img-src  https://openmaptiles.github.io/ https://api.mapbox.com/ 'self' data: blob:; script-src https://matomo.fabrique.social.gouv.fr/ blob: 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://api.tiles.mapbox.com/; manifest-src 'self';";
+      more_set_headers "Content-Security-Policy: default-src https://matomo.fabrique.social.gouv.fr/; connect-src *.cegedim.cloud https://*.pjm.social.gouv.fr/ https://matomo.fabrique.social.gouv.fr/ https://openmaptiles.geo.data.gouv.fr/ https://openmaptiles.github.io/ https://api-adresse.data.gouv.fr https://entreprise.data.gouv.fr https://nominatim.openstreetmap.org; font-src 'self'; img-src  https://openmaptiles.github.io/ https://api.mapbox.com/ 'self' data: blob:; script-src https://matomo.fabrique.social.gouv.fr/ blob: 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://api.tiles.mapbox.com/; manifest-src 'self';";
 spec:
   {{ if .Values.tlsEnabled -}}
   tls:


### PR DESCRIPTION
changement des règles CSP pour la partie connect, avec les URL de production en .pjm.social.gouv.fr et les environnements non production en .cegedim.cloud  
