### PR TITLE
[K8S] ingress class handling

### DIFF
--- a/packages/api/.k8s/templates/ingress.yaml
+++ b/packages/api/.k8s/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_clear_headers "Server";
 spec:
+  {{ if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{ end -}}
   {{ if .Values.tlsEnabled -}}
   tls:
     - hosts:

--- a/packages/app/.k8s/templates/ingress.yaml
+++ b/packages/app/.k8s/templates/ingress.yaml
@@ -15,6 +15,9 @@ metadata:
       more_set_headers "X-Content-Type-Options: nosniff";
       more_set_headers "Content-Security-Policy: default-src https://matomo.fabrique.social.gouv.fr/; connect-src *.dev.fabrique.social.gouv.fr https://api-emjpm.fabrique.social.gouv.fr/api/ https://emjpm.fabrique.social.gouv.fr https://hasura-emjpm.fabrique.social.gouv.fr/v1/graphql https://matomo.fabrique.social.gouv.fr/ https://openmaptiles.geo.data.gouv.fr/ https://openmaptiles.github.io/ https://api-adresse.data.gouv.fr https://entreprise.data.gouv.fr https://nominatim.openstreetmap.org; font-src 'self'; img-src  https://openmaptiles.github.io/ https://api.mapbox.com/ 'self' data: blob:; script-src https://matomo.fabrique.social.gouv.fr/ blob: 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://api.tiles.mapbox.com/; manifest-src 'self';";
 spec:
+  {{ if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{ end -}}
   {{ if .Values.tlsEnabled -}}
   tls:
     - hosts:

--- a/packages/hasura/.k8s/templates/ingress.yaml
+++ b/packages/hasura/.k8s/templates/ingress.yaml
@@ -13,6 +13,9 @@ metadata:
     nginx.ingress.kubernetes.io/configuration-snippet: |
       more_clear_headers "Server";
 spec:
+  {{ if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  {{ end -}}
   {{ if .Values.tlsEnabled -}}
   tls:
     - hosts:


### PR DESCRIPTION
# K8s  
Ajout du support des [ingress class](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class),  
nécessaire a certain cloud provider comme **Cegedim.Cloud** pour spécifier un *ingress controller* différent de l'*ingress controller* par defaut  

